### PR TITLE
Add missing properties from forks

### DIFF
--- a/src/Response/Embeds/Funding.php
+++ b/src/Response/Embeds/Funding.php
@@ -69,6 +69,12 @@ class Funding extends AbstractResponse
     /** @var string */
     public $DownloadLink;
 
+    /** @var string */
+    public $ReferenceText;
+
+    /** @var string */
+    public $AccountNumber;
+
     /**
      * @param string $FundingDate
      *

--- a/src/Response/Embeds/Transaction.php
+++ b/src/Response/Embeds/Transaction.php
@@ -101,7 +101,7 @@ class Transaction extends AbstractResponse
     public $CreditCardMaskedPan;
 
     /**
-     * @var string
+     * @var bool
      */
     public $IsTokenized;
 
@@ -286,6 +286,18 @@ class Transaction extends AbstractResponse
     public $InvoiceOrderInfo;
 
     /**
+     * @param string $IsTokenized
+     *
+     * @return $this
+     */
+    protected function setIsTokenized($IsTokenized)
+    {
+        $this->IsTokenized = filter_var($IsTokenized, FILTER_VALIDATE_BOOLEAN);
+
+        return $this;
+    }
+
+    /**
      * @param string $CreatedDate
      *
      * @return $this
@@ -310,7 +322,7 @@ class Transaction extends AbstractResponse
     }
 
     /**
-     * @param float $ReservedAmount
+     * @param string $ReservedAmount
      *
      * @return $this
      */
@@ -322,7 +334,7 @@ class Transaction extends AbstractResponse
     }
 
     /**
-     * @param float $CapturedAmount
+     * @param string $CapturedAmount
      *
      * @return $this
      */
@@ -334,7 +346,7 @@ class Transaction extends AbstractResponse
     }
 
     /**
-     * @param float $CreditedAmount
+     * @param string $CreditedAmount
      *
      * @return $this
      */
@@ -346,7 +358,7 @@ class Transaction extends AbstractResponse
     }
 
     /**
-     * @param float $SurchargeAmount
+     * @param string $SurchargeAmount
      *
      * @return $this
      */
@@ -358,7 +370,7 @@ class Transaction extends AbstractResponse
     }
 
     /**
-     * @param float $RefundedAmount
+     * @param string $RefundedAmount
      *
      * @return $this
      */
@@ -370,7 +382,7 @@ class Transaction extends AbstractResponse
     }
 
     /**
-     * @param float $RecurringDefaultAmount
+     * @param string $RecurringDefaultAmount
      *
      * @return $this
      */
@@ -382,7 +394,7 @@ class Transaction extends AbstractResponse
     }
 
     /**
-     * @param float $FraudRiskScore
+     * @param string $FraudRiskScore
      *
      * @return $this
      */

--- a/tests/Api/PaymentsTest.php
+++ b/tests/Api/PaymentsTest.php
@@ -127,7 +127,7 @@ class PaymentsTest extends AbstractApiTest
         $this->assertSame('Valid', $data->CardStatus);
         $this->assertSame('93f534a2f5d66d6ab3f16c8a7bb7e852656d4bb2', $data->CreditCardToken);
         $this->assertSame('411111******1111', $data->CreditCardMaskedPan);
-        $this->assertSame('false', $data->IsTokenized);
+        $this->assertSame(false, $data->IsTokenized);
         $this->assertSame('Not_Applicable', $data->ThreeDSecureResult);
         $this->assertSame('Merchant', $data->LiableForChargeback);
         $this->assertSame('4f244dec4907eba0f6432e53b17a60ebcf51365e', $data->BlacklistToken);


### PR DESCRIPTION
Referenced from view-source:https://testgateway.altapaysecure.com/APIResponse.xsd

Parameters where added in this fork https://github.com/luxplus/altapay-php-api, so presumably needed by @Shawnley or Luxplus