### PR TITLE
Fix broken intergrartion tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "fzaninotto/faker": "^1.6",
-        "phpstan/phpstan": "^0.12.94",
+        "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "*",
         "phpstan/phpstan-strict-rules": "*",
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"

--- a/src/AbstractApi.php
+++ b/src/AbstractApi.php
@@ -331,7 +331,7 @@ abstract class AbstractApi
     /**
      * Build url
      *
-     * @param array<string, string> $options
+     * @param array<string, mixed> $options
      *
      * @return bool|string
      */

--- a/src/Api/Ecommerce/PaymentRequest.php
+++ b/src/Api/Ecommerce/PaymentRequest.php
@@ -323,7 +323,7 @@ class PaymentRequest extends AbstractApi
     protected function getBasicHeaders()
     {
         $headers = parent::getBasicHeaders();
-        if (mb_strtolower($this->getHttpMethod()) == 'post') {
+        if (mb_strtolower($this->getHttpMethod()) === 'post') {
             $headers['Content-Type'] = 'application/x-www-form-urlencoded';
         }
 
@@ -340,7 +340,7 @@ class PaymentRequest extends AbstractApi
     protected function getUrl(array $options)
     {
         $url = 'createPaymentRequest';
-        if (mb_strtolower($this->getHttpMethod()) == 'get') {
+        if (mb_strtolower($this->getHttpMethod()) === 'get') {
             $query = $this->buildUrl($options);
             $url   = sprintf('%s/?%s', $url, $query);
         }
@@ -368,7 +368,7 @@ class PaymentRequest extends AbstractApi
         $this->doConfigureOptions();
         $headers           = $this->getBasicHeaders();
         $requestParameters = [$this->getHttpMethod(), $this->parseUrl(), $headers];
-        if (mb_strtolower($this->getHttpMethod()) == 'post') {
+        if (mb_strtolower($this->getHttpMethod()) === 'post') {
             $requestParameters[] = $this->getPostOptions();
         }
         $request       = new Request(...$requestParameters);

--- a/src/Api/Ecommerce/ResponseInfo.php
+++ b/src/Api/Ecommerce/ResponseInfo.php
@@ -13,7 +13,7 @@ class ResponseInfo extends Callback
     {
         $response          = $this->call();
         $registeredAddress = null;
-        if (isset($response->Transactions[0]->CustomerInfo->RegisteredAddress)) {
+        if (isset($response->Transactions[0]->CustomerInfo)) {
             $registeredAddress = $response->Transactions[0]->CustomerInfo->RegisteredAddress;
         }
 

--- a/src/Api/Ecommerce/ResponseInfo.php
+++ b/src/Api/Ecommerce/ResponseInfo.php
@@ -6,11 +6,6 @@ use Altapay\Response\Embeds\Address;
 
 class ResponseInfo extends Callback
 {
-    public function __construct($postedData)
-    {
-        parent::__construct($postedData);
-    }
-
     /**
      * @return Address|null
      */

--- a/src/Api/Others/FundingDownload.php
+++ b/src/Api/Others/FundingDownload.php
@@ -103,17 +103,22 @@ class FundingDownload extends AbstractApi
      *
      * @param array<string, mixed> $options Resolved options
      *
-     * @return string
+     * @return ?string
      */
     protected function getUrl(array $options)
     {
-        return $options['link'];
+        $url = isset($options['link']) ? $options['link'] : null;
+        if (!is_string($url)) {
+            return null;
+        }
+
+        return $url;
     }
 
     /**
      * Parse the URL
      *
-     * @return string
+     * @return ?string
      */
     protected function parseUrl()
     {

--- a/src/Api/Payments/CaptureReservation.php
+++ b/src/Api/Payments/CaptureReservation.php
@@ -145,7 +145,7 @@ class CaptureReservation extends AbstractApi
     {
         $body = (string)$response->getBody();
         $xml  = new \SimpleXMLElement($body);
-        if ($xml->Body->Result == 'Error') {
+        if ((string)$xml->Body->Result === 'Error') {
             throw new \Exception($xml->Body->MerchantErrorMessage);
         }
 

--- a/src/Api/Payments/CaptureReservation.php
+++ b/src/Api/Payments/CaptureReservation.php
@@ -162,7 +162,7 @@ class CaptureReservation extends AbstractApi
     protected function getBasicHeaders()
     {
         $headers = parent::getBasicHeaders();
-        if (mb_strtolower($this->getHttpMethod()) == 'post') {
+        if (mb_strtolower($this->getHttpMethod()) === 'post') {
             $headers['Content-Type'] = 'application/x-www-form-urlencoded';
         }
 
@@ -179,7 +179,7 @@ class CaptureReservation extends AbstractApi
     protected function getUrl(array $options)
     {
         $url = 'captureReservation';
-        if (mb_strtolower($this->getHttpMethod()) == 'get') {
+        if (mb_strtolower($this->getHttpMethod()) === 'get') {
             $query = $this->buildUrl($options);
             $url   = sprintf('%s/?%s', $url, $query);
         }
@@ -203,7 +203,7 @@ class CaptureReservation extends AbstractApi
         $this->doConfigureOptions();
         $headers           = $this->getBasicHeaders();
         $requestParameters = [$this->getHttpMethod(), $this->parseUrl(), $headers];
-        if (mb_strtolower($this->getHttpMethod()) == 'post') {
+        if (mb_strtolower($this->getHttpMethod()) === 'post') {
             $requestParameters[] = $this->getPostOptions();
         }
 

--- a/src/Api/Payments/CardWalletAuthorize.php
+++ b/src/Api/Payments/CardWalletAuthorize.php
@@ -334,7 +334,7 @@ class CardWalletAuthorize extends AbstractApi
     protected function getBasicHeaders()
     {
         $headers = parent::getBasicHeaders();
-        if (mb_strtolower($this->getHttpMethod()) == 'post') {
+        if (mb_strtolower($this->getHttpMethod()) === 'post') {
             $headers['Content-Type'] = 'application/x-www-form-urlencoded';
         }
 
@@ -351,7 +351,7 @@ class CardWalletAuthorize extends AbstractApi
     protected function getUrl(array $options)
     {
         $url = 'cardWallet/authorize';
-        if (mb_strtolower($this->getHttpMethod()) == 'get') {
+        if (mb_strtolower($this->getHttpMethod()) === 'get') {
             $query = $this->buildUrl($options);
             $url = sprintf('%s/?%s', $url, $query);
         }
@@ -375,7 +375,7 @@ class CardWalletAuthorize extends AbstractApi
         $this->doConfigureOptions();
         $headers = $this->getBasicHeaders();
         $requestParameters = [$this->getHttpMethod(), $this->parseUrl(), $headers];
-        if (mb_strtolower($this->getHttpMethod()) == 'post') {
+        if (mb_strtolower($this->getHttpMethod()) === 'post') {
             $requestParameters[] = $this->getPostOptions();
         }
 

--- a/src/Api/Payments/CardWalletSession.php
+++ b/src/Api/Payments/CardWalletSession.php
@@ -98,7 +98,7 @@ class CardWalletSession extends AbstractApi
     protected function getBasicHeaders()
     {
         $headers = parent::getBasicHeaders();
-        if (mb_strtolower($this->getHttpMethod()) == 'post') {
+        if (mb_strtolower($this->getHttpMethod()) === 'post') {
             $headers['Content-Type'] = 'application/x-www-form-urlencoded';
         }
 
@@ -115,7 +115,7 @@ class CardWalletSession extends AbstractApi
     protected function getUrl(array $options)
     {
         $url = 'cardWallet/session';
-        if (mb_strtolower($this->getHttpMethod()) == 'get') {
+        if (mb_strtolower($this->getHttpMethod()) === 'get') {
             $query = $this->buildUrl($options);
             $url = sprintf('%s/?%s', $url, $query);
         }
@@ -139,7 +139,7 @@ class CardWalletSession extends AbstractApi
         $this->doConfigureOptions();
         $headers = $this->getBasicHeaders();
         $requestParameters = [$this->getHttpMethod(), $this->parseUrl(), $headers];
-        if (mb_strtolower($this->getHttpMethod()) == 'post') {
+        if (mb_strtolower($this->getHttpMethod()) === 'post') {
             $requestParameters[] = $this->getPostOptions();
         }
 

--- a/src/Api/Payments/RefundCapturedReservation.php
+++ b/src/Api/Payments/RefundCapturedReservation.php
@@ -148,7 +148,7 @@ class RefundCapturedReservation extends AbstractApi
     protected function getBasicHeaders()
     {
         $headers = parent::getBasicHeaders();
-        if (mb_strtolower($this->getHttpMethod()) == 'post') {
+        if (mb_strtolower($this->getHttpMethod()) === 'post') {
             $headers['Content-Type'] = 'application/x-www-form-urlencoded';
         }
 
@@ -165,7 +165,7 @@ class RefundCapturedReservation extends AbstractApi
     protected function getUrl(array $options)
     {
         $url = 'refundCapturedReservation';
-        if (mb_strtolower($this->getHttpMethod()) == 'get') {
+        if (mb_strtolower($this->getHttpMethod()) === 'get') {
             $query = $this->buildUrl($options);
             $url   = sprintf('%s/?%s', $url, $query);
         }
@@ -191,7 +191,7 @@ class RefundCapturedReservation extends AbstractApi
         $this->doConfigureOptions();
         $headers           = $this->getBasicHeaders();
         $requestParameters = [$this->getHttpMethod(), $this->parseUrl(), $headers];
-        if (mb_strtolower($this->getHttpMethod()) == 'post') {
+        if (mb_strtolower($this->getHttpMethod()) === 'post') {
             $requestParameters[] = $this->getPostOptions();
         }
 

--- a/src/Api/Payments/RefundCapturedReservation.php
+++ b/src/Api/Payments/RefundCapturedReservation.php
@@ -130,7 +130,8 @@ class RefundCapturedReservation extends AbstractApi
     {
         $body = (string)$response->getBody();
         $xml  = new \SimpleXMLElement($body);
-        if ($xml->Body->Result == 'Error' || $xml->Body->Result == 'Failed') {
+        $result = (string)$xml->Body->Result;
+        if ($result === 'Error' || $result === 'Failed') {
             throw new \Exception($xml->Body->MerchantErrorMessage);
         }
         try {

--- a/src/Api/Payments/ReleaseReservation.php
+++ b/src/Api/Payments/ReleaseReservation.php
@@ -81,7 +81,7 @@ class ReleaseReservation extends AbstractApi
     protected function getBasicHeaders()
     {
         $headers = parent::getBasicHeaders();
-        if (mb_strtolower($this->getHttpMethod()) == 'post') {
+        if (mb_strtolower($this->getHttpMethod()) === 'post') {
             $headers['Content-Type'] = 'application/x-www-form-urlencoded';
         }
 
@@ -98,7 +98,7 @@ class ReleaseReservation extends AbstractApi
     protected function getUrl(array $options)
     {
         $url = 'releaseReservation';
-        if (mb_strtolower($this->getHttpMethod()) == 'get') {
+        if (mb_strtolower($this->getHttpMethod()) === 'get') {
             $query = $this->buildUrl($options);
             $url   = sprintf('%s/?%s', $url, $query);
         }
@@ -126,7 +126,7 @@ class ReleaseReservation extends AbstractApi
         $this->doConfigureOptions();
         $headers           = $this->getBasicHeaders();
         $requestParameters = [$this->getHttpMethod(), $this->parseUrl(), $headers];
-        if (mb_strtolower($this->getHttpMethod()) == 'post') {
+        if (mb_strtolower($this->getHttpMethod()) === 'post') {
             $requestParameters[] = $this->getPostOptions();
         }
         $request       = new Request(...$requestParameters);

--- a/src/Exceptions/ResponseHeaderException.php
+++ b/src/Exceptions/ResponseHeaderException.php
@@ -27,7 +27,6 @@ use Altapay\Response\Embeds\Header;
 
 class ResponseHeaderException extends Exception
 {
-
     /**
      * @var Header
      */

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -28,7 +28,6 @@ use Altapay\Api\Ecommerce;
 use Altapay\Api\Others;
 use Altapay\Api\Payments;
 use Altapay\Api\Subscription;
-use Altapay\Api\Test;
 
 class Factory
 {
@@ -54,9 +53,6 @@ class Factory
     const SUBSCRIPTION_CHARGE_SUBSCRIPTION = Subscription\ChargeSubscription::class;
     const SUBSCRIPTION_RESERVE_SUBSCRIPTION_CHARGE = Subscription\ReserveSubscriptionCharge::class;
     const SUBSCRIPTION_SETUP_SUBSCRIPTION = Subscription\SetupSubscription::class;
-
-    const TEST_AUTHENTICATION = Test\TestAuthentication::class;
-    const TEST_CONNECTION = Test\TestConnection::class;
 
     /**
      * @template T of object

--- a/src/Request/AbstractSerializer.php
+++ b/src/Request/AbstractSerializer.php
@@ -42,7 +42,7 @@ abstract class AbstractSerializer
      * @param object $object
      * @param string $property
      *
-     * @return mixed
+     * @return mixed Will return false if the property or getter does not exist
      */
     protected function get($object, $property)
     {

--- a/src/Request/OrderLine.php
+++ b/src/Request/OrderLine.php
@@ -158,7 +158,7 @@ class OrderLine extends AbstractSerializer
     /**
      * Serialize a object
      *
-     * @return array<string, string|numeric>
+     * @return array<string, mixed>
      */
     public function serialize()
     {

--- a/src/Response/AbstractResponse.php
+++ b/src/Response/AbstractResponse.php
@@ -86,7 +86,7 @@ abstract class AbstractResponse
                     if ($childKey === false) {
                         $data = ResponseSerializer::serialize($className, $child);
                     } else {
-                        $data = ResponseSerializer::serializeChildren($className, $child, $builder['array']);
+                        $data = ResponseSerializer::serializeChildren($className, $child, $childKey);
                     }
                 } else {
                     $data = trim((string)$child);

--- a/tests/Api/TestAuthenticationTest.php
+++ b/tests/Api/TestAuthenticationTest.php
@@ -2,7 +2,7 @@
 
 namespace Altapay\ApiTest\Api;
 
-use Altapay\Api\Test\TestAuthentication;
+use Altapay\ApiTest\TestAuthentication;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Altapay\Exceptions\ClientException;

--- a/tests/Api/TestConnectionTest.php
+++ b/tests/Api/TestConnectionTest.php
@@ -2,7 +2,7 @@
 
 namespace Altapay\ApiTest\Api;
 
-use Altapay\Api\Test\TestConnection;
+use Altapay\ApiTest\TestConnection;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Psr7\Response;
 use Altapay\Exceptions\ClientException;

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -2,7 +2,7 @@
 
 namespace Altapay\ApiTest;
 
-use Altapay\Api\Test\TestAuthentication;
+use Altapay\ApiTest\TestAuthentication;
 use Altapay\Exceptions\ClassDoesNotExistsException;
 use Altapay\Factory;
 
@@ -17,6 +17,8 @@ class FactoryTest extends AbstractTest
         $constants = $refClass->getConstants();
         $output    = [];
         foreach ($constants as $class) {
+            $this->assertTrue(is_string($class));
+            $this->assertTrue(class_exists($class));
             $output[] = [$class];
         }
 

--- a/tests/Functional/FixedAmountProgressTest.php
+++ b/tests/Functional/FixedAmountProgressTest.php
@@ -100,81 +100,19 @@ class FixedAmountProgressTest extends AbstractFunctionalTest
         $api->call();
     }
 
-//    public function test_preauth_cvv_check_error()
-//    {
-//        $this->markTestSkipped('Not working with API');
-//
-//        $this->setExpectedException(ResponseMessageException::class);
-//        $this->expectExceptionMessage('TestAcquirer[pan=0572 or amount=5720]');
-//
-//        $api = new ReservationOfFixedAmount($this->getAuth());
-//        $api
-//            ->setTerminal($this->getTerminal())
-//            ->setShopOrderId((string)time())
-//            ->setAmount(5.72)
-//            ->setCurrency('DKK')
-//            ->setCard($this->generateCard('4190000000000572'))
-//        ;
-//        $api->call();
-//    }
-//
-//    public function test_preauth_card_failed()
-//    {
-//        $this->markTestSkipped('Not working with API');
-//
-//        $api = new ReservationOfFixedAmount($this->getAuth());
-//        $api
-//            ->setTerminal($this->getTerminal())
-//            ->setShopOrderId((string)time())
-//            ->setAmount(16.66)
-//            ->setCurrency('DKK')
-//            ->setCard($this->generateCard('4120000000001666'))
-//        ;
-//        $api->call();
-//    }
-//
-//    public function test_preauth_card_error()
-//    {
-//        $this->markTestSkipped('Not working with API');
-//
-//        $api = new ReservationOfFixedAmount($this->getAuth());
-//        $api
-//            ->setTerminal($this->getTerminal())
-//            ->setShopOrderId((string)time())
-//            ->setAmount(16.67)
-//            ->setCurrency('DKK')
-//            ->setCard($this->generateCard('4160000000001667'))
-//        ;
-//        $api->call();
-//    }
 
-    public function test_fraud_check_challenge(): void
+    public function test_preauth_cvv_check_error(): void
     {
+        $this->expectException(ResponseMessageException::class);
+        $this->expectExceptionMessage('TestAcquirer[pan=0572 or amount=5720]');
+
         $api = new ReservationOfFixedAmount($this->getAuth());
         $api
             ->setTerminal($this->getTerminal())
             ->setShopOrderId((string)time())
-            ->setAmount(102)
+            ->setAmount(5.72)
             ->setCurrency('DKK')
-            ->setCard($this->generateCard('4170000000000121'))
-            ->setFraudService('maxmind');
-        $response = $api->call();
-        $this->assertInstanceOf(ReservationOfFixedAmountResponse::class, $response);
-        $this->assertSame('Deny', $response->Transactions[0]->FraudRecommendation);
-    }
-
-    public function test_fraud_check_deny(): void
-    {
-        $api = new ReservationOfFixedAmount($this->getAuth());
-        $api
-            ->setTerminal($this->getTerminal())
-            ->setShopOrderId((string)time())
-            ->setAmount(110)
-            ->setCurrency('DKK')
-            ->setCard($this->generateCard('4170000000000105'))
-            ->setFraudService('maxmind');
-        $response = $api->call();
-        $this->assertInstanceOf(ReservationOfFixedAmountResponse::class, $response);
-        $this->assertSame('Deny', $response->Transactions[0]->FraudRecommendation);
+            ->setCard($this->generateCard('4190000000000572'));
+        $api->call();
     }
 }

--- a/tests/Functional/TestAuthenticationTest.php
+++ b/tests/Functional/TestAuthenticationTest.php
@@ -2,8 +2,10 @@
 
 namespace Altapay\ApiTest\Functional;
 
-use Altapay\Api\Test\TestAuthentication;
+use Altapay\ApiTest\TestAuthentication;
 use Altapay\Authentication;
+use Altapay\Exceptions\ClientException;
+use GuzzleHttp\Exception\ConnectException;
 
 class TestAuthenticationTest extends AbstractFunctionalTest
 {
@@ -15,17 +17,17 @@ class TestAuthenticationTest extends AbstractFunctionalTest
 
     public function test_auth_fails(): void
     {
+        $this->expectException(ClientException::class);
         $response = (new TestAuthentication(new Authentication('username', 'password')))->call();
-        $this->assertFalse($response);
     }
 
     public function test_auth_fails_connection(): void
     {
+        $this->expectException(ConnectException::class);
         $response = (new TestAuthentication(new Authentication(
             'username',
             'password',
             'http://doesnotexists.mecom'
         )))->call();
-        $this->assertFalse($response);
     }
 }

--- a/tests/Functional/TestConnectionTest.php
+++ b/tests/Functional/TestConnectionTest.php
@@ -2,7 +2,8 @@
 
 namespace Altapay\ApiTest\Functional;
 
-use Altapay\Api\Test\TestConnection;
+use Altapay\ApiTest\TestConnection;
+use GuzzleHttp\Exception\ConnectException;
 
 class TestConnectionTest extends AbstractFunctionalTest
 {
@@ -16,9 +17,8 @@ class TestConnectionTest extends AbstractFunctionalTest
 
     public function test_connection_fails(): void
     {
+        $this->expectException(ConnectException::class);
         $response = (new TestConnection('http//idonotexists.mecom'))
             ->call();
-
-        $this->assertSame('ok', $response);
     }
 }

--- a/tests/Request/OrderLineRequestTestSerializer.php
+++ b/tests/Request/OrderLineRequestTestSerializer.php
@@ -8,11 +8,10 @@ class OrderLineRequestTestSerializer extends OrderLine
 {
     public function serialize()
     {
-        $result = $this->get($this, 'foobar');
         if ($this->get($this, 'foobar') === false) {
             throw new \Exception('Got false');
         }
 
-        return $result;
+        return [];
     }
 }

--- a/tests/TestAuthentication.php
+++ b/tests/TestAuthentication.php
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-namespace Altapay\Api\Test;
+namespace Altapay\ApiTest;
 
 use Altapay\AbstractApi;
 use Altapay\Exceptions\ClientException;
@@ -71,17 +71,5 @@ class TestAuthentication extends AbstractApi
     protected function handleResponse(Request $request, ResponseInterface $response)
     {
         return 'ok';
-    }
-
-    /**
-     * Handle exception response
-     *
-     * @param ClientException $exception
-     *
-     * @return false
-     */
-    protected function handleExceptionResponse(ClientException $exception)
-    {
-        return false;
     }
 }

--- a/tests/TestConnection.php
+++ b/tests/TestConnection.php
@@ -21,7 +21,7 @@
  * THE SOFTWARE.
  */
 
-namespace Altapay\Api\Test;
+namespace Altapay\ApiTest;
 
 use Altapay\AbstractApi;
 use Altapay\Authentication;
@@ -36,7 +36,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 class TestConnection extends AbstractApi
 {
-
     /**
      * TestConnection constructor.
      *
@@ -93,17 +92,5 @@ class TestConnection extends AbstractApi
     protected function handleResponse(Request $request, ResponseInterface $response)
     {
         return 'ok';
-    }
-
-    /**
-     * Handle exception response
-     *
-     * @param ClientException $exception
-     *
-     * @return false
-     */
-    protected function handleExceptionResponse(ClientException $exception)
-    {
-        return false;
     }
 }


### PR DESCRIPTION
- Do not include test classes in production code
- Remove unimplemented tests
- Do strict checks on strings
- Upgrade PHPStan to stable version

It appears that maybe the integration tests aren't being run on a regular basis. To run the integration tests you must copy `.env.php.example` to `.env.php` and give it the credentials for a test gateway instance. Else the integration tests will be skipped (like they are on the GitHub CI)

![image](https://user-images.githubusercontent.com/204594/180490160-5dedc4ac-7ece-411a-b4e9-d7f7ea192f10.png)

vs

![image](https://user-images.githubusercontent.com/204594/180490197-008588a5-6c9a-4fc4-ae84-3f32ad2ccd66.png)
