### PR TITLE
Narrow array types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
         "fzaninotto/faker": "^1.6",
-        "phpstan/phpstan": "^1.8",
+        "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "*",
         "phpstan/phpstan-strict-rules": "*",
         "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"

--- a/src/Api/Ecommerce/PaymentRequest.php
+++ b/src/Api/Ecommerce/PaymentRequest.php
@@ -306,10 +306,10 @@ class PaymentRequest extends AbstractApi
         $resolver->setAllowedValues('language', Types\LanguageTypes::getAllowed());
         $resolver->setDefault('type', 'payment');
         $resolver->setAllowedValues('type', Types\PaymentTypes::getAllowed());
-        $resolver->setAllowedValues('sale_reconciliation_identifier', function ($value) {
+        $resolver->setAllowedValues('sale_reconciliation_identifier', function (string $value) {
             return mb_strlen($value) <= 100;
         });
-        $resolver->setAllowedValues('sale_invoice_number', function ($value) {
+        $resolver->setAllowedValues('sale_invoice_number', function (string $value) {
             return mb_strlen($value) <= 100;
         });
         $resolver->setAllowedTypes('sales_tax', ['int', 'float']);
@@ -320,7 +320,7 @@ class PaymentRequest extends AbstractApi
         $resolver->setNormalizer('config', function (Options $options, Config $value) {
             return $value->serialize();
         });
-        $resolver->setAllowedValues('organisation_number', function ($value) {
+        $resolver->setAllowedValues('organisation_number', function (string $value) {
             return mb_strlen($value) <= 20;
         });
         $resolver->setAllowedTypes('account_offer', 'bool');

--- a/src/Api/Others/Payments.php
+++ b/src/Api/Others/Payments.php
@@ -97,7 +97,7 @@ class Payments extends AbstractApi
      * @param Request $request
      * @param ResponseInterface $response
      *
-     * @return Transaction[]
+     * @return list<Transaction>
      * @throws \Exception
      */
     protected function handleResponse(Request $request, ResponseInterface $response)

--- a/src/Api/Payments/CardWalletAuthorize.php
+++ b/src/Api/Payments/CardWalletAuthorize.php
@@ -291,10 +291,10 @@ class CardWalletAuthorize extends AbstractApi
         $resolver->setAllowedValues('language', Types\LanguageTypes::getAllowed());
         $resolver->setDefault('type', 'payment');
         $resolver->setAllowedValues('type', Types\PaymentTypes::getAllowed());
-        $resolver->setAllowedValues('sale_reconciliation_identifier', function ($value) {
+        $resolver->setAllowedValues('sale_reconciliation_identifier', function (string $value) {
             return mb_strlen($value) <= 100;
         });
-        $resolver->setAllowedValues('sale_invoice_number', function ($value) {
+        $resolver->setAllowedValues('sale_invoice_number', function (string $value) {
             return mb_strlen($value) <= 100;
         });
         $resolver->setAllowedTypes('sales_tax', ['int', 'float']);
@@ -305,7 +305,7 @@ class CardWalletAuthorize extends AbstractApi
         $resolver->setNormalizer('config', function (Options $options, Config $value) {
             return $value->serialize();
         });
-        $resolver->setAllowedValues('organisation_number', function ($value) {
+        $resolver->setAllowedValues('organisation_number', function (string $value) {
             return mb_strlen($value) <= 20;
         });
         $resolver->setAllowedTypes('account_offer', 'bool');

--- a/src/Api/Payments/ReservationOfFixedAmount.php
+++ b/src/Api/Payments/ReservationOfFixedAmount.php
@@ -303,7 +303,7 @@ class ReservationOfFixedAmount extends AbstractApi
             return $value->serialize();
         });
         $resolver->setAllowedTypes('surcharge', ['int', 'float']);
-        $resolver->setAllowedValues('sale_invoice_number', function ($value) {
+        $resolver->setAllowedValues('sale_invoice_number', function (string $value) {
             return mb_strlen($value) <= 100;
         });
         $resolver->setNormalizer('cardnum', function (Options $options, $value) {

--- a/src/Request/Customer.php
+++ b/src/Request/Customer.php
@@ -841,11 +841,11 @@ class Customer extends AbstractSerializer
         }
 
         if ($this->clientJavascriptEnabled !== null) {
-            $output['client_javascript_enabled'] = $this->clientJavascriptEnabled;
+            $output['client_javascript_enabled'] = (string)$this->clientJavascriptEnabled;
         }
 
         if ($this->clientJavaEnabled !== null) {
-            $output['client_java_enabled'] = $this->clientJavaEnabled;
+            $output['client_java_enabled'] = (string)$this->clientJavaEnabled;
         }
 
         if ($this->clientColorDepth) {

--- a/src/Request/OrderLine.php
+++ b/src/Request/OrderLine.php
@@ -25,7 +25,7 @@ namespace Altapay\Request;
 
 class OrderLine extends AbstractSerializer
 {
-    /** @var array<int, string> */
+    /** @var list<string> */
     private static $goodsTypes = [
         'shipment',
         'handling',

--- a/src/Serializer/ResponseSerializer.php
+++ b/src/Serializer/ResponseSerializer.php
@@ -62,7 +62,7 @@ class ResponseSerializer
      * @param \SimpleXMLElement $data
      * @param string            $childKey
      *
-     * @return array<int, T>
+     * @return list<T>
      * @throws \InvalidArgumentException
      */
     public static function serializeChildren(
@@ -72,7 +72,7 @@ class ResponseSerializer
     ) {
         $documents = [];
 
-        if (! empty($data) && ! empty($data->{$childKey})) {
+        if (! empty($data) && ! empty($data->{$childKey}) && $data->{$childKey} instanceof \SimpleXMLElement) {
             foreach ($data->{$childKey} as $d) {
                 $object      = new $objectName();
                 $documents[] = $object->deserialize($d);

--- a/src/Traits/CsvToArrayTrait.php
+++ b/src/Traits/CsvToArrayTrait.php
@@ -35,7 +35,7 @@ trait CsvToArrayTrait
      *
      * @param bool $includeHeader
      *
-     * @return array<int, array<int, string|null>>
+     * @return list<list<string|null>>
      */
     public function __toArray($includeHeader = false)
     {

--- a/src/Traits/CurrencyTrait.php
+++ b/src/Traits/CurrencyTrait.php
@@ -51,7 +51,7 @@ trait CurrencyTrait
     protected function setCurrencyResolver(OptionsResolver $resolver)
     {
         $resolver->setAllowedTypes('currency', ['string', 'int']);
-        $resolver->setAllowedValues('currency', function ($value) {
+        $resolver->setAllowedValues('currency', function (string $value) {
             return CurrencyTypes::currencyCodeExists($value) || CurrencyTypes::currencyNumberExists($value);
         });
     }

--- a/src/Traits/OrderlinesTrait.php
+++ b/src/Traits/OrderlinesTrait.php
@@ -44,17 +44,6 @@ trait OrderlinesTrait
         }
 
         if (is_array($orderLines)) {
-            foreach ($orderLines as $orderLine) {
-                if (!$orderLine instanceof OrderLine) {
-                    throw new \InvalidArgumentException(
-                        sprintf(
-                            'orderLines should all be a instance of "%s"',
-                            OrderLine::class
-                        )
-                    );
-                }
-            }
-
             $this->unresolvedOptions['orderLines'] = $orderLines;
         }
 
@@ -68,10 +57,10 @@ trait OrderlinesTrait
     {
         $resolver->addAllowedTypes('orderLines', 'array');
         /** @noinspection PhpUnusedParameterInspection */
-        $resolver->setNormalizer('orderLines', function (Options $options, $value) {
+        $resolver->setNormalizer('orderLines', function (Options $options, array $value) {
             $output = [];
-            /** @var OrderLine $object */
             foreach ($value as $object) {
+                assert($object instanceof OrderLine);
                 $output[] = $object->serialize();
             }
             return $output;

--- a/src/Types/FraudServices.php
+++ b/src/Types/FraudServices.php
@@ -31,7 +31,7 @@ class FraudServices implements TypeInterface
     /**
      * Allowed fraud services
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     private static $services = [
         'none',
@@ -43,7 +43,7 @@ class FraudServices implements TypeInterface
     /**
      * Get allowed values
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     public static function getAllowed()
     {

--- a/src/Types/LanguageTypes.php
+++ b/src/Types/LanguageTypes.php
@@ -30,7 +30,7 @@ class LanguageTypes implements TypeInterface
      * nb, nn will be converted to no.
      * ee will be converted to et
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     private static $languages = [
         'br', 'ca', 'cs', 'cy', 'da', 'de', 'el', 'en', 'es', 'fi', 'fr', 'hr', 'hu', 'is', 'ja',
@@ -41,7 +41,7 @@ class LanguageTypes implements TypeInterface
     /**
      * Get allowed values
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     public static function getAllowed()
     {

--- a/src/Types/PaymentSources.php
+++ b/src/Types/PaymentSources.php
@@ -31,7 +31,7 @@ class PaymentSources implements TypeInterface
     /**
      * Allowed payment sources
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     private static $sources = [
         'eCommerce',
@@ -44,7 +44,7 @@ class PaymentSources implements TypeInterface
     /**
      * Get allowed values
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     public static function getAllowed()
     {

--- a/src/Types/PaymentTypes.php
+++ b/src/Types/PaymentTypes.php
@@ -31,7 +31,7 @@ class PaymentTypes implements TypeInterface
     /**
      * Allowed payment types
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     private static $types = [
         'payment',
@@ -45,7 +45,7 @@ class PaymentTypes implements TypeInterface
     /**
      * Get allowed values
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     public static function getAllowed()
     {

--- a/src/Types/SelectedSchemes.php
+++ b/src/Types/SelectedSchemes.php
@@ -31,7 +31,7 @@ class SelectedSchemes implements TypeInterface
     /**
      * Allowed selected schemes
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     private static $schemes = [
         'VISA',
@@ -51,7 +51,7 @@ class SelectedSchemes implements TypeInterface
     /**
      * Get allowed values
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     public static function getAllowed()
     {

--- a/src/Types/ShippingMethods.php
+++ b/src/Types/ShippingMethods.php
@@ -28,7 +28,7 @@ class ShippingMethods implements TypeInterface
     /**
      * Allowed payment types
      *
-     * @var array<int, string>
+     * @var list<string>
      */
     private static $types = [
         'LowCost',
@@ -45,7 +45,7 @@ class ShippingMethods implements TypeInterface
     /**
      * Get allowed values
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     public static function getAllowed()
     {

--- a/src/Types/TypeInterface.php
+++ b/src/Types/TypeInterface.php
@@ -28,7 +28,7 @@ interface TypeInterface
     /**
      * Get allowed values
      *
-     * @return array<int, string>
+     * @return list<string>
      */
     public static function getAllowed();
 

--- a/tests/Api/CallbackTest.php
+++ b/tests/Api/CallbackTest.php
@@ -162,7 +162,6 @@ XML
     {
         $call     = new Callback($this->data);
         $response = $call->call();
-        $this->assertInstanceOf(CallbackResponse::class, $response);
         $this->assertSame('d28df6b4-122d-49e2-add0-19c8271260b0', $response->paymentId);
         $this->assertSame('000000022', $response->shopOrderId);
         $this->assertSame('incomplete', $response->status);

--- a/tests/Api/CaptureReservationTest.php
+++ b/tests/Api/CaptureReservationTest.php
@@ -54,7 +54,6 @@ class CaptureReservationTest extends AbstractApiTest
         $response = $api->call();
         $this->assertInstanceOf(CaptureReservationResponse::class, $response);
         $transaction = $response->Transactions[0];
-        $this->assertInstanceOf(Transaction::class, $transaction);
         $this->assertSame('1', $transaction->TransactionId);
         $this->assertSame('978', $transaction->MerchantCurrency);
         $this->assertSame(13.37, $transaction->FraudRiskScore);

--- a/tests/Api/CreditTest.php
+++ b/tests/Api/CreditTest.php
@@ -84,7 +84,7 @@ class CreditTest extends AbstractApiTest
     }
 
     /**
-     * @return array<int, array<int, string>>
+     * @return list<list<string>>
      */
     public function paymentSourceDataProvider()
     {

--- a/tests/Api/FundingListTest.php
+++ b/tests/Api/FundingListTest.php
@@ -77,16 +77,13 @@ class FundingListTest extends AbstractApiTest
         $response = $api->call();
         $this->assertInstanceOf(FundingsResponse::class, $response);
         $funding = $response->Fundings[0];
-        $this->assertInstanceOf(Funding::class, $funding);
 
         $this->assertSame('CreatedByTest', $funding->Filename);
         $this->assertSame('1234567890123456', $funding->ContractIdentifier);
         $this->assertCount(2, $funding->Shops);
         $this->assertSame('TestAcquirer', $funding->Acquirer);
-        $this->assertInstanceOf(\DateTime::class, $funding->FundingDate);
         $this->assertSame('26-09-2010', $funding->FundingDate->format('d-m-Y'));
         $this->assertSame('50.00 EUR', $funding->Amount);
-        $this->assertInstanceOf(\DateTime::class, $funding->CreatedDate);
         $this->assertSame('27-09-2010', $funding->CreatedDate->format('d-m-Y'));
         $this->assertSame('http://localhost/merchant.php/API/fundingDownload?id=1', $funding->DownloadLink);
     }

--- a/tests/Api/HeaderTest.php
+++ b/tests/Api/HeaderTest.php
@@ -34,7 +34,6 @@ class HeaderTest extends AbstractApiTest
             $api = $this->getapi();
             $api->call();
         } catch (ResponseHeaderException $e) {
-            $this->assertInstanceOf(Header::class, $e->getHeader());
             $this->assertSame('200', $e->getHeader()->ErrorCode);
             $this->assertSame('This request has error', $e->getHeader()->ErrorMessage);
         }

--- a/tests/Api/InvoiceTextTest.php
+++ b/tests/Api/InvoiceTextTest.php
@@ -58,14 +58,11 @@ class InvoiceTextTest extends AbstractApiTest
         $this->assertStringStartsWith('Fordringen er overdraget', $response->MandatoryInvoiceText);
         $this->assertSame('7373', $response->InvoiceNumber);
         $this->assertSame('832', $response->CustomerNumber);
-        $this->assertInstanceOf(\DateTime::class, $response->InvoiceDate);
         $this->assertSame('10-03-2011', $response->InvoiceDate->format('d-m-Y'));
-        $this->assertInstanceOf(\DateTime::class, $response->DueDate);
         $this->assertSame('24-03-2011', $response->DueDate->format('d-m-Y'));
         $this->assertCount(1, $response->TextInfos);
         $this->assertSame('Password', $response->TextInfos[0]->Name);
         $this->assertSame('xxxxxx', $response->TextInfos[0]->Value);
-        $this->assertInstanceOf(Address::class, $response->Address);
         $this->assertSame('John', $response->Address->Firstname);
         $this->assertSame('John', $response->Address->Lastname);
         $this->assertSame('Anywhere Street 12', $response->Address->Address);

--- a/tests/Api/PaymentRequestTest.php
+++ b/tests/Api/PaymentRequestTest.php
@@ -117,7 +117,6 @@ class PaymentRequestTest extends AbstractApiTest
         $this->assertSame('kg', $line['unitCode']);
 
         // Config
-        $this->assertIsArray($parts['config']);
         /** @var array<string> $config */
         $config = $parts['config'];
         $this->assertSame(sprintf('%s/%s', self::CONFIG_URL, 'form'), $config['callback_form']);
@@ -203,7 +202,7 @@ class PaymentRequestTest extends AbstractApiTest
     }
 
     /**
-     * @param string|TypeInterface $class
+     * @param class-string<TypeInterface>|TypeInterface $class
      * @param string               $key
      * @param string               $setter
      */
@@ -228,7 +227,7 @@ class PaymentRequestTest extends AbstractApiTest
     }
 
     /**
-     * @param string|TypeInterface $class
+     * @param class-string<TypeInterface>|TypeInterface $class
      * @param string               $key
      * @param string               $method
      */

--- a/tests/Api/PaymentsTest.php
+++ b/tests/Api/PaymentsTest.php
@@ -73,7 +73,6 @@ class PaymentsTest extends AbstractApiTest
             ->setPaymentId('mypaymentid');
         $api->call();
 
-        $this->assertInstanceOf(Request::class, $api->getRawRequest());
         $this->assertInstanceOf(Response::class, $api->getRawResponse());
 
         $this->assertSame($this->getExceptedUri('payments/'), $api->getRawRequest()->getUri()->getPath());
@@ -120,7 +119,6 @@ class PaymentsTest extends AbstractApiTest
     public function test_multiple_payment_transaction_data(): void
     {
         $data = $this->getMultiplePaymentTransaction()[0];
-        $this->assertInstanceOf(Transaction::class, $data);
 
         $this->assertSame('1', $data->TransactionId);
         $this->assertSame('ccc1479c-37f9-4962-8d2c-662d75117e9d', $data->PaymentId);
@@ -144,8 +142,6 @@ class PaymentsTest extends AbstractApiTest
         $this->assertSame(1.00, $data->CapturedAmount);
         $this->assertSame(0.0, $data->RefundedAmount);
         $this->assertSame(0.0, $data->RecurringDefaultAmount);
-        $this->assertInstanceOf(\DateTime::class, $data->CreatedDate);
-        $this->assertInstanceOf(\DateTime::class, $data->UpdatedDate);
         $this->assertSame('28-09-2010', $data->CreatedDate->format('d-m-Y'));
         $this->assertSame('28-09-2010', $data->UpdatedDate->format('d-m-Y'));
         $this->assertSame('CreditCard', $data->PaymentNature);
@@ -153,14 +149,8 @@ class PaymentsTest extends AbstractApiTest
         $this->assertSame(13.37, $data->FraudRiskScore);
         $this->assertSame('Fraud detection explanation', $data->FraudExplanation);
 
-        // Payment nature service
-        $this->assertInstanceOf(PaymentNatureService::class, $data->PaymentNatureService);
-
         // Payment Infos
         $this->assertCount(3, $data->PaymentInfos);
-
-        // Customer info
-        $this->assertInstanceOf(CustomerInfo::class, $data->CustomerInfo);
 
         // ReconciliationIdentifiers
         $this->assertCount(1, $data->ReconciliationIdentifiers);
@@ -172,7 +162,6 @@ class PaymentsTest extends AbstractApiTest
     public function test_multiple_payment_paymentnatureservice_data(): void
     {
         $data = $this->getMultiplePaymentTransaction()[0]->PaymentNatureService;
-        $this->assertInstanceOf(PaymentNatureService::class, $data);
 
         $this->assertSame('TestAcquirer', $data->name);
         $this->assertTrue($data->SupportsRefunds);
@@ -182,7 +171,7 @@ class PaymentsTest extends AbstractApiTest
     }
 
     /**
-     * @return array<int, array<int, mixed>>
+     * @return list<list<mixed>>
      */
     public function paymentinfosDataprovider()
     {
@@ -234,17 +223,12 @@ class PaymentsTest extends AbstractApiTest
         $this->assertSame('support', $data->Username);
         $this->assertSame('+45 7020 0056', $data->CustomerPhone);
         $this->assertSame('12345678', $data->OrganisationNumber);
-        $this->assertInstanceOf(Country::class, $data->CountryOfOrigin);
 
         $country = $data->CountryOfOrigin;
-        $this->assertInstanceOf(Country::class, $country);
         $this->assertSame('DK', $country->Country);
         $this->assertSame('BillingAddress', $country->Source);
 
-        $this->assertInstanceOf(Address::class, $data->BillingAddress);
-
         $address = $data->BillingAddress;
-        $this->assertInstanceOf(Address::class, $address);
         $this->assertSame('Palle', $address->Firstname);
         $this->assertSame('Simonsen', $address->Lastname);
         $this->assertSame('Rosenkæret 13', $address->Address);
@@ -252,18 +236,13 @@ class PaymentsTest extends AbstractApiTest
         $this->assertSame('2860', $address->PostalCode);
         $this->assertSame('DK', $address->Country);
 
-        $this->assertInstanceOf(Address::class, $data->ShippingAddress);
-
         $address = $data->ShippingAddress;
-        $this->assertInstanceOf(Address::class, $address);
         $this->assertNull($address->Firstname);
         $this->assertNull($address->Lastname);
         $this->assertNull($address->Address);
         $this->assertNull($address->City);
         $this->assertNull($address->PostalCode);
         $this->assertNull($address->Country);
-
-        $this->assertInstanceOf(Address::class, $data->RegisteredAddress);
     }
 
     /**
@@ -272,12 +251,10 @@ class PaymentsTest extends AbstractApiTest
     public function test_multiple_payment_reconciliationidentifiers_data(): void
     {
         $data = $this->getMultiplePaymentTransaction()[0]->ReconciliationIdentifiers[0];
-        $this->assertInstanceOf(ReconciliationIdentifier::class, $data);
 
         $this->assertSame('f4e2533e-c578-4383-b075-bc8a6866784a', $data->Id);
         $this->assertSame(1.00, $data->Amount);
         $this->assertSame('captured', $data->Type);
-        $this->assertInstanceOf(\DateTime::class, $data->Date);
         $this->assertSame('28-09-2010', $data->Date->format('d-m-Y'));
         $this->assertSame('978', $data->currency);
     }

--- a/tests/Api/RefundCapturedReservationTest.php
+++ b/tests/Api/RefundCapturedReservationTest.php
@@ -57,7 +57,6 @@ class RefundCapturedReservationTest extends AbstractApiTest
         $response = $api->call();
         $this->assertInstanceOf(RefundResponse::class, $response);
         $transaction = $response->Transactions[0];
-        $this->assertInstanceOf(Transaction::class, $transaction);
         $this->assertSame('1', $transaction->TransactionId);
         $this->assertSame('978', $transaction->MerchantCurrency);
         $this->assertSame(13.37, $transaction->FraudRiskScore);

--- a/tests/Api/ReservationOfFixedAmountTest.php
+++ b/tests/Api/ReservationOfFixedAmountTest.php
@@ -355,8 +355,7 @@ class ReservationOfFixedAmountTest extends AbstractApiTest
                 'agreement[unscheduled]' => 'incremental'
             ]
         );
-        $transactionInfo[] = 'Trans 1';
-        $transactionInfo[] = 'Trans 2';
+        $transactionInfo = ['Trans 1', 'Trans 2'];
         $api->setTransactionInfo($transactionInfo);
         $api->call();
 
@@ -412,7 +411,7 @@ class ReservationOfFixedAmountTest extends AbstractApiTest
     }
 
     /**
-     * @param string|TypeInterface $class
+     * @param class-string<TypeInterface>|TypeInterface $class
      * @param string               $key
      * @param string               $setter
      */
@@ -437,7 +436,7 @@ class ReservationOfFixedAmountTest extends AbstractApiTest
     }
 
     /**
-     * @param string|TypeInterface $class
+     * @param class-string<TypeInterface>|TypeInterface $class
      * @param string               $key
      * @param string               $method
      */

--- a/tests/Api/TerminalsTest.php
+++ b/tests/Api/TerminalsTest.php
@@ -33,7 +33,6 @@ class TerminalsTest extends AbstractApiTest
         $api      = $this->getTerminals();
         $response = $api->call();
         $this->assertInstanceOf(TerminalsResponse::class, $response);
-        $this->assertInstanceOf(\DateTime::class, $response->Header->Date);
         $this->assertSame('07-01-2016', $response->Header->Date->format('d-m-Y'));
         $this->assertSame('API/getTerminals', $response->Header->Path);
         $this->assertSame('0', $response->Header->ErrorCode);
@@ -61,8 +60,6 @@ class TerminalsTest extends AbstractApiTest
         $this->assertCount(2, $response->Terminals);
 
         $terminal = $response->Terminals[0];
-        $this->assertInstanceOf(Terminal::class, $terminal);
-        $this->assertSame('AltaPay Multi-Nature Terminal', $terminal->Title);
         $this->assertSame('DK', $terminal->Country);
         $this->assertCount(4, $terminal->Natures);
         $this->assertCount(4, $terminal->Methods);

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -5,11 +5,12 @@ namespace Altapay\ApiTest;
 use Altapay\ApiTest\TestAuthentication;
 use Altapay\Exceptions\ClassDoesNotExistsException;
 use Altapay\Factory;
+use stdClass;
 
 class FactoryTest extends AbstractTest
 {
     /**
-     * @return array<int, array<int, class-string>>
+     * @return list<list<class-string>>
      */
     public function dataProvider()
     {
@@ -40,7 +41,7 @@ class FactoryTest extends AbstractTest
         $this->expectException(ClassDoesNotExistsException::class);
 
         /** @var class-string */
-        $invalidClassName = 'Foo\Bar';
+        $invalidClassName = $this->noneExistingClass();
 
         Factory::create($invalidClassName, $this->getAuth());
     }
@@ -48,12 +49,17 @@ class FactoryTest extends AbstractTest
     public function test_does_not_exists_exception_catch(): void
     {
         /** @var class-string */
-        $invalidClassName = 'Foo\Bar';
+        $invalidClassName = $this->noneExistingClass();
 
         try {
             Factory::create($invalidClassName, $this->getAuth());
         } catch (ClassDoesNotExistsException $e) {
-            $this->assertSame('Foo\Bar', $e->getClass());
+            $this->assertSame($invalidClassName, $e->getClass());
         }
+    }
+    
+    private function noneExistingClass(): string
+    {
+        return 'Foo\Bar';
     }
 }

--- a/tests/Functional/AbstractFunctionalTest.php
+++ b/tests/Functional/AbstractFunctionalTest.php
@@ -27,7 +27,10 @@ abstract class AbstractFunctionalTest extends AbstractTest
      */
     protected function getAuth()
     {
-        return new Authentication($_ENV['USERNAME'], $_ENV['PASSWORD'], $this->getBaseUrl());
+        $username = $_ENV['USERNAME'] ?? null;
+        $password = $_ENV['PASSWORD'] ?? null;
+
+        return new Authentication(is_string($username) ? $username : '', is_string($password) ? $password : '', $this->getBaseUrl());
     }
 
     /**
@@ -35,7 +38,9 @@ abstract class AbstractFunctionalTest extends AbstractTest
      */
     protected function getBaseUrl()
     {
-        return $_ENV['BASEURL'];
+        $baseUrl = $_ENV['BASEURL'] ?? null;
+
+        return is_string($baseUrl) ? $baseUrl : '';
     }
 
     /**
@@ -43,7 +48,9 @@ abstract class AbstractFunctionalTest extends AbstractTest
      */
     protected function getTerminal()
     {
-        return $_ENV['TERMINAL'];
+        $terminal = $_ENV['TERMINAL'] ?? null;
+
+        return is_string($terminal) ? $terminal : '';
     }
 
     /**

--- a/tests/Functional/FixedAmountProgressTest.php
+++ b/tests/Functional/FixedAmountProgressTest.php
@@ -38,7 +38,6 @@ class FixedAmountProgressTest extends AbstractFunctionalTest
                 ->setCurrency('DKK');
             $api->call();
         } catch (ResponseHeaderException $e) {
-            $this->assertInstanceOf(Header::class, $e->getHeader());
         }
     }
 

--- a/tests/Functional/TerminalsTest.php
+++ b/tests/Functional/TerminalsTest.php
@@ -11,6 +11,7 @@ class TerminalsTest extends AbstractFunctionalTest
     {
         $response = (new Terminals($this->getAuth()))->call();
         $this->assertInstanceOf(TerminalsResponse::class, $response);
-        $this->assertCount($_ENV['NUMBER_OF_TERMINALS'], $response->Terminals);
+        $this->assertTrue(is_numeric($_ENV['NUMBER_OF_TERMINALS']));
+        $this->assertCount((int)$_ENV['NUMBER_OF_TERMINALS'], $response->Terminals);
     }
 }

--- a/tests/Request/OrderLineTest.php
+++ b/tests/Request/OrderLineTest.php
@@ -46,7 +46,7 @@ class OrderLineTest extends AbstractTest
     }
 
     /**
-     * @return array<int, array<int, mixed>>
+     * @return list<list<mixed>>
      */
     public function dataProvider()
     {


### PR DESCRIPTION
The main motivation for this PR is to document when a simple list is returned rather then a sparse array. This lets the consumer know that if `count($data) > 4` then keys 0-3 exists allowing for simpler and safe data handeling.

Additionally this upgrade PHPStan to 2.1 (from 1.12) and resolves all new issues detected by the upgraded tool.